### PR TITLE
Add findBySku and updateBySku methods

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -36,8 +36,7 @@ jobs:
           mvn spring-boot:run &
           sleep 10 # TODO: loop/curl actuator health endpoint instead
           npm --prefix gui ci
-          echo $(google-chrome --version | cut -d ' ' -f 3)
-          npm --prefix gui run webdriver-manager update --versions.chrome=$(google-chrome --version | cut -d ' ' -f 3)
+          npm --prefix gui run -- webdriver-manager update --versions.chrome="$(google-chrome --version | cut -d ' ' -f 3)"
           npm --prefix gui run e2e
   publish:
     name: Publish Docker image

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -37,7 +37,7 @@ jobs:
           sleep 10 # TODO: loop/curl actuator health endpoint instead
           npm --prefix gui ci
           npm --prefix gui run -- webdriver-manager update --versions.chrome="$(google-chrome --version | cut -d ' ' -f 3)"
-          npm --prefix gui run e2e
+          npm --prefix gui run -- ng e2e --webdriver-update=false
   publish:
     name: Publish Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -36,7 +36,8 @@ jobs:
           mvn spring-boot:run &
           sleep 10 # TODO: loop/curl actuator health endpoint instead
           npm --prefix gui ci
-          npm --prefix gui run webdriver-manager update
+          echo $(google-chrome --version | cut -d ' ' -f 3)
+          npm --prefix gui run webdriver-manager update --versions.chrome=$(google-chrome --version | cut -d ' ' -f 3)
           npm --prefix gui run e2e
   publish:
     name: Publish Docker image

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -34,8 +34,9 @@ jobs:
       - name: Run e2e tests
         run: |
           mvn spring-boot:run &
-          sleep 10
+          sleep 10 # TODO: loop/curl actuator health endpoint instead
           npm --prefix gui ci
+          npm --prefix gui run webdriver-manager update
           npm --prefix gui run e2e
   publish:
     name: Publish Docker image

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ testem.log
 .DS_Store
 Thumbs.db
 target
+
+### Skaffold ###
+.skaffold
+skaffold.yaml

--- a/gui/src/app/article/article.service.spec.ts
+++ b/gui/src/app/article/article.service.spec.ts
@@ -131,7 +131,7 @@ describe('ArticleService', () => {
     });
     service.deleteBySku(sku);
 
-    const req = httpMock.expectOne(req => req.method === 'DELETE' && req.url === '/api/article');
+    const req = httpMock.expectOne(req => req.method === 'DELETE' && req.url === '/api/article/deleteBySku');
     expect(req.request.params.get('sku')).toEqual(sku);
     req.flush(null, {
       headers: {

--- a/gui/src/app/article/article.service.ts
+++ b/gui/src/app/article/article.service.ts
@@ -48,7 +48,7 @@ export class ArticleService {
   }
 
   public deleteBySku(sku: string): void {
-    this.http.delete('/api/article', {
+    this.http.delete('/api/article/deleteBySku', {
       params: new HttpParams().set('sku', sku)
     }).subscribe(_ => {
       this.publish(this.articles.filter(article => article.sku !== sku));

--- a/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleController.java
+++ b/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleController.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @RepositoryRestController
@@ -16,7 +18,23 @@ public class ArticleController {
     this.articleRepository = articleRepository;
   }
 
-  @DeleteMapping(value = "/article")
+  @PatchMapping(value = "/article/updateQuantityBySku")
+  public ResponseEntity<Article> updateQuantityBySku(@RequestParam("sku") String sku, @RequestBody ArticleQuantityUpdate data) {
+    Article found = this.articleRepository.findBySku(sku);
+    if (found == null) {
+      return ResponseEntity.notFound().build();
+    }
+    int count = this.articleRepository.updateQuantityBySku(sku, data.getCurrentQuantity(), data.getNewQuantity());
+    if (count == 0) {
+      return ResponseEntity.badRequest().build();
+    } else {
+      Article updated = new Article(found.getId(), found.getSku(), found.getName(), found.getDescription(),
+        found.getPriceInUsd(), found.getImageUrl(), data.getNewQuantity());
+      return ResponseEntity.ok(updated);
+    }
+  }
+
+  @DeleteMapping(value = "/article/deleteBySku")
   public ResponseEntity<Article> deleteBySku(@RequestParam("sku") String sku) {
     this.articleRepository.deleteBySku(sku);
     return ResponseEntity.noContent().build();

--- a/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleQuantityUpdate.java
+++ b/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleQuantityUpdate.java
@@ -1,0 +1,34 @@
+package io.projectriff.samples.shopping.inventoryapi.article;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ArticleQuantityUpdate {
+
+  private final int currentQuantity;
+
+  private final int newQuantity;
+
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public ArticleQuantityUpdate(@JsonProperty("currentQuantity") int currentQuantity,
+                               @JsonProperty("newQuantity") int newQuantity) {
+    this.currentQuantity = currentQuantity;
+    this.newQuantity = newQuantity;
+  }
+
+  public int getCurrentQuantity() {
+    return currentQuantity;
+  }
+
+  public int getNewQuantity() {
+    return newQuantity;
+  }
+
+  @Override
+  public String toString() {
+    return "ArticleQuantity{" +
+      "currentQuantity=" + currentQuantity +
+      ", newQuantity=" + newQuantity +
+      '}';
+  }
+}

--- a/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepository.java
+++ b/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 @RepositoryRestResource(path = "article")
 public interface ArticleRepository extends CrudRepository<Article, Long> {
@@ -12,10 +13,12 @@ public interface ArticleRepository extends CrudRepository<Article, Long> {
   @Query("SELECT id,sku,name,description,price_in_usd,image_url,quantity FROM article WHERE sku = :sku")
   Article findBySku(@Param("sku") String sku);
 
+  @RestResource(exported = false)
   @Modifying
   @Query("UPDATE article SET quantity = :to WHERE sku = :sku AND quantity = :from")
-  int updateBySku(@Param("sku") String sku, @Param("from") int from, @Param("to") int to);
+  int updateQuantityBySku(@Param("sku") String sku, @Param("from") int from, @Param("to") int to);
 
+  @RestResource(exported = false)
   @Modifying
   @Query("DELETE FROM article WHERE sku = :sku")
   void deleteBySku(@Param("sku") String sku);

--- a/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepository.java
+++ b/src/main/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepository.java
@@ -5,12 +5,18 @@ import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
-import org.springframework.data.rest.core.annotation.RestResource;
 
 @RepositoryRestResource(path = "article")
 public interface ArticleRepository extends CrudRepository<Article, Long> {
 
+  @Query("SELECT id,sku,name,description,price_in_usd,image_url,quantity FROM article WHERE sku = :sku")
+  Article findBySku(@Param("sku") String sku);
+
   @Modifying
-  @Query("DELETE FROM Article WHERE sku = :sku")
+  @Query("UPDATE article SET quantity = :to WHERE sku = :sku AND quantity = :from")
+  int updateBySku(@Param("sku") String sku, @Param("from") int from, @Param("to") int to);
+
+  @Modifying
+  @Query("DELETE FROM article WHERE sku = :sku")
   void deleteBySku(@Param("sku") String sku);
 }

--- a/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleApiTest.java
+++ b/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleApiTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.core.Is.is;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -72,6 +73,43 @@ class ArticleApiTest {
         "    \"articles\" : %s\n" +
         "  }\n" +
         "}", objectMapper.writeValueAsString(articles))));
+
+  }
+
+  @Test
+  @DisplayName("finds articles via API")
+  void find_article() throws Exception {
+    List<Article> articles = Arrays.asList(
+      new Article("sku 1", "name 1", "description 1", BigDecimal.ONE, null, 1),
+      new Article("sku 2", "name 2", "description 2", BigDecimal.TEN, null, 2)
+    );
+    Article articleToFind = articles.get(0);
+    articles.forEach(jdbcHelper::save);
+
+    mockMvc.perform(get("/api/article/search/findBySku/?sku={sku}", articleToFind.getSku())
+      .contentType(APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(content().json(objectMapper.writeValueAsString(articleToFind)));
+
+  }
+
+  @Test
+  @DisplayName("updates quantity for articles via API")
+  void update_article() throws Exception {
+    List<Article> articles = Arrays.asList(
+      new Article("sku 1", "name 1", "description 1", BigDecimal.ONE, null, 1),
+      new Article("sku 2", "name 2", "description 2", BigDecimal.TEN, null, 2)
+    );
+    Article articleToUpdate = articles.get(0);
+    articles.forEach(jdbcHelper::save);
+    ArticleQuantityUpdate newQuantity = new ArticleQuantityUpdate(articleToUpdate.getQuantity(), 0);
+    Article updatedArticle = new Article("sku 1", "name 1", "description 1", BigDecimal.ONE, null, 0);
+
+    mockMvc.perform(patch("/api/article/updateQuantityBySku/?sku={sku}", articleToUpdate.getSku())
+      .content(objectMapper.writeValueAsString(newQuantity))
+      .contentType(APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(content().json(objectMapper.writeValueAsString(updatedArticle)));
 
   }
 

--- a/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleApiTest.java
+++ b/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleApiTest.java
@@ -82,7 +82,7 @@ class ArticleApiTest {
     Article article2 = new Article("sku 2", "name 2", "description 2", BigDecimal.TEN, null, 7);
     Arrays.asList(article1, article2).forEach(jdbcHelper::save);
 
-    mockMvc.perform(delete("/api/article/?sku={sku}", article1.getSku()))
+    mockMvc.perform(delete("/api/article/deleteBySku/?sku={sku}", article1.getSku()))
       .andExpect(status().isNoContent());
   }
 

--- a/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepositoryTest.java
+++ b/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepositoryTest.java
@@ -50,6 +50,32 @@ class ArticleRepositoryTest {
   }
 
   @Test
+  @DisplayName("Finds articles by SKU")
+  void find_article_by_sku() {
+    jdbcHelper.save(article);
+    jdbcHelper.save(otherArticle);
+
+    Article found = repository.findBySku(article.getSku());
+
+    assertThat(repository.findAll()).containsExactly(article, otherArticle);
+    assertThat(found.getSku()).isEqualTo(article.getSku());
+  }
+
+  @Test
+  @DisplayName("Updates quantity for articles by SKU")
+  void update_article_by_sku() {
+    jdbcHelper.save(article);
+    jdbcHelper.save(otherArticle);
+
+    int count = repository.updateQuantityBySku(article.getSku(), 12, 11);
+
+    Article updatedArticle = new Article("some SKU", "some name", "description", BigDecimal.TEN, null, 11);
+
+    assertThat(repository.findAll()).containsExactly(updatedArticle, otherArticle);
+    assertThat(count).isEqualTo(1);
+  }
+
+@Test
   @DisplayName("Deletes articles by SKU")
   void deletes_article_by_sku() {
     jdbcHelper.save(article);

--- a/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepositoryTest.java
+++ b/src/test/java/io/projectriff/samples/shopping/inventoryapi/article/ArticleRepositoryTest.java
@@ -69,7 +69,8 @@ class ArticleRepositoryTest {
 
     int count = repository.updateQuantityBySku(article.getSku(), 12, 11);
 
-    Article updatedArticle = new Article("some SKU", "some name", "description", BigDecimal.TEN, null, 11);
+    Article updatedArticle = new Article(article.getSku(), article.getName(),
+      article.getDescription(), article.getPriceInUsd(), article.getImageUrl(), 11);
 
     assertThat(repository.findAll()).containsExactly(updatedArticle, otherArticle);
     assertThat(count).isEqualTo(1);


### PR DESCRIPTION
Adding an `/article/updateBySku` PATCH method so we can update inventory quantities

- only update if the current inventory quantity matches the passed in quantity to update from

- also adding `/article/findBySku` method

- renaming path for delete to `/article/deleteBySku`

- updating UI with the above path

- hiding the custom repository methods from being exposed as part of `/article/search`